### PR TITLE
Modifiche alla struttura della guida per il cap. "Pillole di semantica dei dati"

### DIFF
--- a/docs/pillole-di-semantica-dei-dati.rst
+++ b/docs/pillole-di-semantica-dei-dati.rst
@@ -53,3 +53,6 @@ Per realizzare quanto sopra, ci sono quattro regole di base da seguire:
   :caption: Indice dei contenuti
 
   pillole-di-semantica-dei-dati/i-pilastri-della-semantica-dei-dati.rst
+
+Le pillole di semantica dei dati sono state redatte grazie alla collaborazione
+tra il Dipartimento di trasformazione digitale e la Prof.ssa Giorgia Lodi del ISTC-CNR.

--- a/index.rst
+++ b/index.rst
@@ -11,8 +11,9 @@ Catalogo, e più in generale ai potenziali utenti del portale
 Per le indicazioni su come esplorare la guida, fai riferimento alla 
 `sezione dedicata <docs/premesse/struttura-nella-presente-guida.html>`__.
 
-Per le definizioni dei concetti semantici affrontati nel corso della guida, 
-fai riferimento alle `Pillole di semantica dei dati <docs/pillole-di-semantica-dei-dati.html>`__.
+Se sei nuovo nel mondo della semantica dei dati, e hai bisogno di
+un'introduzione generale sul tema, fai riferimento alle 
+`Pillole di semantica dei dati <docs/pillole-di-semantica-dei-dati.html>`__.
 
 .. toctree::
   :maxdepth: 3
@@ -23,4 +24,8 @@ fai riferimento alle `Pillole di semantica dei dati <docs/pillole-di-semantica-d
   docs/come-contribuire.rst
   docs/come-utilizzare-le-risorse.rst
   docs/manuale-operativo.rst
+  
+.. toctree::
+  :name: content_toc
+  
   docs/pillole-di-semantica-dei-dati.rst


### PR DESCRIPTION
La presente PR include le modifiche:

- Eliminazione numerazione per il capitolo "Pillole di semantica dei dati". Il capitolo rimane visibile sia nel relativo indice del Sommario, sia nella side-bar di navigazione a sinistra della pagina, sempre senza numerazione (screenshot a fine testo).
- Modifica della frase che rimanda alle pillole nel Sommario (home-page della guida) --> "_Se sei nuovo nel mondo della semantica dei dati, e hai bisogno di un’introduzione generale sul tema, fai riferimento alle [Pillole di semantica dei dati]._"
- Aggiunta di una frase al termine del cap. Pillole di semantica dei dati --> "_Le pillole di semantica dei dati sono state redatte grazie alla collaborazione tra il Dipartimento di trasformazione digitale e la Prof.ssa Giorgia Lodi del ISTC-CNR._"

@giorgialodi @Clou-dia per favore fatemi sapere se e come ritenete necessario modificare le due frasi dell'elenco sopra, anche con un commento a questa PR.

![image](https://github.com/teamdigitale/dati-semantic-guida-ndc-docs/assets/132351416/99226bd4-5cad-4079-97a7-07f53a017b3a)

![image](https://github.com/teamdigitale/dati-semantic-guida-ndc-docs/assets/132351416/20a029f0-a21a-4a95-a0db-79b72cbdbc73)

CC: @mauropratesi 

